### PR TITLE
Backward сompatibility fix for prepareSession()

### DIFF
--- a/src/Sauce/Sausage/WebDriverTestCase.php
+++ b/src/Sauce/Sausage/WebDriverTestCase.php
@@ -135,9 +135,9 @@ abstract class WebDriverTestCase extends \PHPUnit_Extensions_Selenium2TestCase
 
     public function prepareSession()
     {
-        parent::prepareSession();
         if ($this->getBuild())
             SauceTestCommon::ReportBuild($this->getSessionId(), $this->getBuild());
+        return parent::prepareSession();
     }
 
     public function tearDown()


### PR DESCRIPTION
Method prepareSession() returns session as in parent class.
