### PR TITLE
Fixed prepareSession() if session not exists

### DIFF
--- a/src/Sauce/Sausage/WebDriverTestCase.php
+++ b/src/Sauce/Sausage/WebDriverTestCase.php
@@ -135,10 +135,10 @@ abstract class WebDriverTestCase extends \PHPUnit_Extensions_Selenium2TestCase
 
     public function prepareSession()
     {
-        parent::prepareSession();
+        $session = parent::prepareSession();
         if ($this->getBuild())
             SauceTestCommon::ReportBuild($this->getSessionId(), $this->getBuild());
-        return parent::prepareSession();
+        return $session;
     }
 
     public function tearDown()


### PR DESCRIPTION
If session not exists `SauceTestCommon::ReportBuild($this->getSessionId(), $this->getBuild())` throws exceptions (Exception: job_id is required).
So we should create session first.
