### PR TITLE
Fixed buildUrl to accept absolute urls using http

### DIFF
--- a/src/Sauce/Sausage/WebDriverTestCase.php
+++ b/src/Sauce/Sausage/WebDriverTestCase.php
@@ -162,7 +162,7 @@ abstract class WebDriverTestCase extends \PHPUnit_Extensions_Selenium2TestCase
 
     protected function buildUrl($url)
     {
-        if ($url !== NULL && $this->base_url !== NULL && !preg_match("/^http(s):/", $url)) {
+        if ($url !== NULL && $this->base_url !== NULL && !preg_match("/^https?:/", $url)) {
             if (strlen($url) && $url[0] == '/') {
                 $sep = '';
             } else {


### PR DESCRIPTION
The new regex allows for the s in https to be optional. 
