### PR TITLE
Fixes setupSpecificBrowser strict standards error

### DIFF
--- a/src/Sauce/Sausage/SeleniumRCTestCase.php
+++ b/src/Sauce/Sausage/SeleniumRCTestCase.php
@@ -9,7 +9,7 @@ abstract class SeleniumRCTestCase extends \PHPUnit_Extensions_SeleniumTestCase
     protected $is_local_test = false;
     protected $build = false;
 
-    public function setupSpecificBrowser($browser)
+    public function setupSpecificBrowser(array $browser)
     {
         $this->getDriver($browser);
         self::ShareSession(false);


### PR DESCRIPTION
Fixes `PHP Strict standards:  Declaration of Sauce\Sausage\SeleniumRCTestCase::setupSpecificBrowser() should be compatible with that of PHPUnit_Extensions_SeleniumTestCase::setupSpecificBrowser()` error
