### PR TITLE
make curl certification checks optional with SAUCE_VERIFY_CERTS env var

### DIFF
--- a/src/Sauce/Sausage/SauceAPI.php
+++ b/src/Sauce/Sausage/SauceAPI.php
@@ -9,7 +9,7 @@ class SauceAPI
     protected $username;
     protected $access_key;
 
-    public function __construct($username, $access_key)
+    public function __construct($username, $access_key, $verify_certs = true)
     {
         if (!$username)
             throw new \Exception("Username is required for SauceAPI");
@@ -17,6 +17,7 @@ class SauceAPI
             throw new \Exception("Access key is required for SauceAPI");
         $this->username = $username;
         $this->access_key = $access_key;
+        $this->verify_certs = $verify_certs;
         $this->methods = new SauceMethods($this->username);
     }
 
@@ -31,6 +32,10 @@ class SauceAPI
     protected function makeRequest($url, $type="GET", $params=false)
     {
         $ch = curl_init();
+        if($this->verify_certs == false) {
+            curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
+            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+        }
 
         curl_setopt($ch, CURLOPT_URL, $url);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);

--- a/src/Sauce/Sausage/SauceConfig.php
+++ b/src/Sauce/Sausage/SauceConfig.php
@@ -37,6 +37,7 @@ EOF;
                 $username = $access_key = NULL;
             }
 
+            define('SAUCE_VERIFY_CERTS', getenv('SAUCE_VERIFY_CERTS') ? getenv('SAUCE_VERIFY_CERTS') : true);
             define('SAUCE_USERNAME', $username);
             define('SAUCE_ACCESS_KEY', $access_key);
         }

--- a/src/Sauce/Sausage/SauceTestCommon.php
+++ b/src/Sauce/Sausage/SauceTestCommon.php
@@ -13,7 +13,7 @@ abstract class SauceTestCommon
     public static function ReportStatus($session_id, $passed)
     {
         self::RequireSauceConfig();
-        $api = new SauceAPI(SAUCE_USERNAME, SAUCE_ACCESS_KEY);
+        $api = new SauceAPI(SAUCE_USERNAME, SAUCE_ACCESS_KEY, SAUCE_VERIFY_CERTS);
         $api->updateJob($session_id, array('passed'=>$passed));
     }
 


### PR DESCRIPTION
See https://github.com/jlipps/sausage/issues/35
I propose to fix this by introducing an opttional environment variable "SAUCE_VERIFY_CERTS" to be able to control curl to ignore certification errors. That way, it's still verified by default, but you can override this in your CI (in my case, in Travis, as thtis causes problems there)

Feedback welcome. 
Thanks!