### PR TITLE
fix SAUCE_DONT_VERIFY_CERTS env var, added tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: php
+php:
+- 5.5
+notifications:
+  email: false
+install:
+- composer self-update
+- composer update --prefer-dist
+script:
+- phpunit tests/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/jlipps/sausage.svg?branch=master)](https://travis-ci.org/jlipps/sausage)
+
 Sausage
 =======
 
@@ -349,6 +351,18 @@ credentials, starting sauce connect is as easy as:
     vendor\bin\sauce_connect.bat
 
 Run that and you'll be testing against your local test server in no time!
+
+Ignoring certificate validation
+---
+
+To connect to saucelabs, cURL is used. Sometimes certificate validation may fail, resulting in an error similar to this:
+
+```
+Exception: Got an error while making a request: server certificate verification failed. CAfile: /etc/ssl/certs/ca-certificates.crt CRLfile: none
+```
+
+You can manually disable curl certificate validation if needed by setting an environment variable `SAUCE_DONT_VERIFY_CERTS`. If any value is set, validation is skipped completely. 
+
 
 Contributors
 ---

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,9 @@
           "url": "https://github.com/appium/php-client"
       }
   ],
+  "require-dev": {
+    "phpunit/phpunit": "4.3.*"
+  },
   "require": {
     "php": ">=5.4.0",
     "sauce/sausage-installer": ">=0.1.0",

--- a/src/Sauce/Sausage/SauceConfig.php
+++ b/src/Sauce/Sausage/SauceConfig.php
@@ -37,7 +37,11 @@ EOF;
                 $username = $access_key = NULL;
             }
 
-            define('SAUCE_VERIFY_CERTS', getenv('SAUCE_VERIFY_CERTS') ? getenv('SAUCE_VERIFY_CERTS') : true);
+            if(getenv('SAUCE_DONT_VERIFY_CERTS')) {
+                define('SAUCE_VERIFY_CERTS', empty(getenv('SAUCE_DONT_VERIFY_CERTS')));
+            } else {
+                define('SAUCE_VERIFY_CERTS', true);
+            }
             define('SAUCE_USERNAME', $username);
             define('SAUCE_ACCESS_KEY', $access_key);
         }

--- a/tests/SauceConfigTest.php
+++ b/tests/SauceConfigTest.php
@@ -1,0 +1,42 @@
+<?php
+
+require_once('vendor/autoload.php');
+require_once('src/Sauce/Sausage/SauceConfig.php');
+
+class SauceConfigTest extends PHPUnit_Framework_TestCase {
+
+	/**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+	public function testLoadConfig_DontVerifyCertsPresent_VerifyCertsFalse() {
+		putenv('SAUCE_DONT_VERIFY_CERTS=1');
+		Sauce\Sausage\SauceConfig::LoadConfig(false);
+
+		$this->assertFalse(SAUCE_VERIFY_CERTS);
+	}
+
+	/**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+	public function testLoadConfig_DontVerifyCertsPresentButEmpty_VerifyCertsTrue() {
+		putenv('SAUCE_DONT_VERIFY_CERTS=');
+		Sauce\Sausage\SauceConfig::LoadConfig(false);
+
+		$this->assertTrue(SAUCE_VERIFY_CERTS);
+	}
+
+	/**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+	public function testLoadConfig_VerifyCertsNotPresent_VerifyCertsTrue() {
+		putenv('SAUCE_DONT_VERIFY_CERTS');
+		Sauce\Sausage\SauceConfig::LoadConfig(false);
+		$this->assertTrue(SAUCE_VERIFY_CERTS);
+	}
+
+}
+
+?>


### PR DESCRIPTION
Hi,

This is a followup on pull request https://github.com/jlipps/sausage/pull/36 - my bad, it seems that PHP evaluates all non-empty strings to true, even 'false', so setting the env var won't really disable anything, whoops :) To counter that, I added unit tests which I should have done the first time. Also updated the README.

It could be a good idea to enable travis to build sausage using 'phpunit tests/' as a script. If you want I can also create a pull request for a travis config file, but you'll have to enable it since I don't own the repository. 