### PR TITLE
fixed fatal error in PHP versions 5.4 and below

### DIFF
--- a/src/Sauce/Sausage/SauceConfig.php
+++ b/src/Sauce/Sausage/SauceConfig.php
@@ -38,7 +38,8 @@ EOF;
             }
 
             if(getenv('SAUCE_DONT_VERIFY_CERTS')) {
-                define('SAUCE_VERIFY_CERTS', empty(getenv('SAUCE_DONT_VERIFY_CERTS')));
+                $env_sauce_dont_verify_certify = getenv('SAUCE_DONT_VERIFY_CERTS');
+                define('SAUCE_VERIFY_CERTS', empty($env_sauce_dont_verify_certify));
             } else {
                 define('SAUCE_VERIFY_CERTS', true);
             }


### PR DESCRIPTION
PHP 5.4 and below don't support expressions as arguments.

http://php.net/manual/en/function.empty.php

