### PR TITLE
Don't default tunnel-identifier to 'False'

### DIFF
--- a/src/Sauce/Sausage/TestCase.php
+++ b/src/Sauce/Sausage/TestCase.php
@@ -27,10 +27,13 @@ trait TestCase
             $this->setDesiredCapabilities($caps);
         }
         
-        if (null !== getenv('SAUCE_TUNNEL_IDENTIFIER')) {
-            $caps = $this->getDesiredCapabilities();
-            $caps['tunnel-identifier'] = getenv('SAUCE_TUNNEL_IDENTIFIER');
-            $this->setDesiredCapabilities($caps);
+        $tunnel_id = getenv('SAUCE_TUNNEL_IDENTIFIER');
+        if (null !== $tunnel_id) {
+            if (false !== $tunnel_id) {
+                $caps = $this->getDesiredCapabilities();
+                $caps['tunnel-identifier'] = $tunnel_id;
+                $this->setDesiredCapabilities($caps);
+            }
         }
     }
 

--- a/src/Sauce/Sausage/TestCase.php
+++ b/src/Sauce/Sausage/TestCase.php
@@ -27,11 +27,11 @@ trait TestCase
             $this->setDesiredCapabilities($caps);
         }
         
-        $tunnel_id = getenv('SAUCE_TUNNEL_IDENTIFIER');
-        if (null !== $tunnel_id) {
-            if (false !== $tunnel_id) {
+        $tunnelId = getenv('SAUCE_TUNNEL_IDENTIFIER');
+        if (null !== $tunnelId) {
+            if (false !== $tunnelId) {
                 $caps = $this->getDesiredCapabilities();
-                $caps['tunnel-identifier'] = $tunnel_id;
+                $caps['tunnel-identifier'] = $tunnelId;
                 $this->setDesiredCapabilities($caps);
             }
         }


### PR DESCRIPTION
Some (at least my) PHP installations return 'false', not null, when requesting non-existent environment variables.  This leads to sessions requesting the tunnel identifier 'False'.  Which is great if you run an identified tunnel named 'False' and otherwise... not so much.