### PR TITLE
Allow users to log SSL details to a file.

### DIFF
--- a/src/Sauce/Sausage/SauceAPI.php
+++ b/src/Sauce/Sausage/SauceAPI.php
@@ -53,6 +53,15 @@ class SauceAPI
         if (getenv('CURL_CA_BUNDLE')) {
             curl_setopt($ch, CURLOPT_CAINFO, getenv('CURL_CA_BUNDLE'));
         }
+        
+        // If user has requested it, be extremely verbose when making requests.
+        // This is primarily intended to help Sauce Support staff figure out what's
+        // busted.
+        if (getenv('SAUCE_DIAGNOSE_SSL')) {
+            curl_setopt($ch, CURLOPT_CERTINFO, true);
+            curl_setopt($ch, CURLOPT_VERBOSE, true);
+            curl_setopt($ch, CURLOPT_STDERR, getenv('SAUCE_DIAGNOSE_SSL'));
+        }
 
         $headers = array();
         $headers[] = 'Content-Type: text/json';


### PR DESCRIPTION
Setting the `SAUCE_DIAGNOSE_SSL` environment variable to a file location will cause Curl to log verbose info, and certification info, to that location.

This will be useful for helping Sauce Support diagnose REST API certificate errors.